### PR TITLE
Filter for ghost digis in the 2015 Pi0 stream

### DIFF
--- a/FillEpsilonPlot/plugins/CleanedDigiCollectionProducer.cc
+++ b/FillEpsilonPlot/plugins/CleanedDigiCollectionProducer.cc
@@ -1,0 +1,83 @@
+#include "CalibCode/FillEpsilonPlot/plugins/CleanedDigiCollectionProducer.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+
+
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+
+#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
+
+#include "FWCore/Utilities/interface/transform.h"
+
+#include <iostream>
+
+CleanedDigiCollectionProducer::CleanedDigiCollectionProducer(const edm::ParameterSet& iConfig) 
+{
+
+  ebDigisToken_ = consumes<EBDigiCollection>(iConfig.getParameter< edm::InputTag > ("ebDigis"));
+  eeDigisToken_ = consumes<EEDigiCollection>(iConfig.getParameter< edm::InputTag > ("eeDigis"));
+	  
+  cleanedEBDigiCollection_ = iConfig.getParameter<std::string>("cleanedEBDigiCollection");
+  cleanedEEDigiCollection_ = iConfig.getParameter<std::string>("cleanedEEDigiCollection");
+  filter_ = iConfig.getParameter<bool>("filter");
+  
+   //register your products
+  produces< EBDigiCollection > (cleanedEBDigiCollection_) ;
+  produces< EEDigiCollection > (cleanedEEDigiCollection_) ;
+  
+}
+
+
+CleanedDigiCollectionProducer::~CleanedDigiCollectionProducer()
+{}
+
+
+// ------------ method called to produce the data  ------------
+bool
+CleanedDigiCollectionProducer::filter (edm::Event& iEvent, 
+                                const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   using namespace std;
+
+   Handle<EBDigiCollection> ebDigisHandle;
+   Handle<EEDigiCollection> eeDigisHandle;
+   iEvent.getByToken(ebDigisToken_,ebDigisHandle);
+   iEvent.getByToken(eeDigisToken_,eeDigisHandle);
+   if( !ebDigisHandle.isValid() || !eeDigisHandle.isValid() ) 
+     {
+       edm::LogError("CleanedDigiCollectionProducer") << "Barrel or Endcap digi collection not found";
+       return false;
+     }
+   
+   //Create empty output collections
+   std::auto_ptr< EBDigiCollection > cleanedEBDigiCollection (new EBDigiCollection()) ;
+   std::auto_ptr< EEDigiCollection > cleanedEEDigiCollection (new EEDigiCollection()) ;
+   
+   for(EBDigiCollection::const_iterator itdg=ebDigisHandle->begin(); itdg!=ebDigisHandle->end(); ++itdg) {
+     DetId detid(itdg->id());
+     if(detid.subdetId()==EcalBarrel)
+       cleanedEBDigiCollection->push_back(itdg->id(),itdg->begin());
+   }
+   for(EEDigiCollection::const_iterator itdg=eeDigisHandle->begin(); itdg!=eeDigisHandle->end(); ++itdg) {
+     DetId detid(itdg->id());
+     if(detid.subdetId()==EcalEndcap)
+       cleanedEEDigiCollection->push_back(itdg->id(),itdg->begin());
+   }
+
+   // Populate the new collections
+   bool pass = (cleanedEBDigiCollection->size() > 0 && cleanedEEDigiCollection->size() > 0);
+   iEvent.put( cleanedEBDigiCollection,cleanedEBDigiCollection_ );
+   iEvent.put( cleanedEEDigiCollection,cleanedEEDigiCollection_ );
+   
+   if(filter_) return pass;
+   else return true;
+}
+
+DEFINE_FWK_MODULE( CleanedDigiCollectionProducer );

--- a/FillEpsilonPlot/plugins/CleanedDigiCollectionProducer.h
+++ b/FillEpsilonPlot/plugins/CleanedDigiCollectionProducer.h
@@ -1,0 +1,44 @@
+#ifndef _CLEANEDDIGICOLLECTIONPRODUCER_H
+#define _CLEANEDDIGICOLLECTIONPRODUCER_H
+
+// -*- C++ -*-
+//
+// Package:    CleanedDigiCollectionProducer
+// Class:      CleanedDigiCollectionProducer
+// 
+
+
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+
+class CleanedDigiCollectionProducer : public edm::stream::EDFilter<> {
+   public:
+      //! ctor
+      explicit CleanedDigiCollectionProducer(const edm::ParameterSet&);
+      ~CleanedDigiCollectionProducer();
+      //! producer
+      virtual bool filter(edm::Event &, const edm::EventSetup&);
+
+   private:
+      // ----------member data ---------------------------
+      edm::EDGetTokenT<EBDigiCollection>     ebDigisToken_;
+      edm::EDGetTokenT<EEDigiCollection>     eeDigisToken_;
+      std::string cleanedEBDigiCollection_;
+      std::string cleanedEEDigiCollection_;
+      bool filter_;
+  
+};
+
+#endif

--- a/FillEpsilonPlot/python/cleanedDigiCollectionProducer_cfi.py
+++ b/FillEpsilonPlot/python/cleanedDigiCollectionProducer_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+cleanedEcalDigis = cms.EDFilter("CleanedDigiCollectionProducer",
+    ebDigis = cms.InputTag("ecalDigis","ebDigis"),
+    eeDigis = cms.InputTag("ecalDigis","eeDigis"),
+    cleanedEBDigiCollection = cms.string('ebCleanedDigis'),
+    cleanedEEDigiCollection = cms.string('eeCleanedDigis'),
+    filter = cms.bool( True )
+)

--- a/submit/methods.py
+++ b/submit/methods.py
@@ -33,6 +33,12 @@ def printFillCfg1( outputfile ):
         outputfile.write("                                     barrelDigiCollection   = cms.untracked.string('dummyBarrelDigis'),\n")
         outputfile.write("                                     endcapDigiCollection   = cms.untracked.string('dummyEndcapDigis'))\n")
         outputfile.write("\n")
+        if(FixGhostDigis):
+            outputfile.write("# GHOST DIGIS CLEANER (FOR 2015 STREAM DATA)\n")
+            outputfile.write("process.load(\"CalibCode.FillEpsilonPlot.cleanedDigiCollectionProducer_cfi\")\n")
+            outputfile.write("process.cleanedEcalDigis.ebDigis = cms.InputTag('dummyHits','dummyBarrelDigis')\n")
+            outputfile.write("process.cleanedEcalDigis.eeDigis = cms.InputTag('dummyHits','dummyEndcapDigis')\n")
+            outputfile.write("\n")
         outputfile.write("#RAW to DIGI'\n")
         outputfile.write("#https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/RecoLocalCalo/EcalRecProducers/test/testMultipleEcalRecoLocal_cfg.py\n")
         outputfile.write("#process.load('Configuration.StandardSequences.RawToDigi_cff')\n")
@@ -48,16 +54,24 @@ def printFillCfg1( outputfile ):
                outputfile.write("process.ecalMultiFitUncalibRecHit.algoPSet.activeBXs = cms.vint32(-4,-2,0,2,4) #Are 10 (-5-5). For 50ns is (-4,-2,0,2,4) #No .algoPSet. in old releases\n")
            if( not is50ns and DigiCustomization ):
                outputfile.write("process.ecalMultiFitUncalibRecHit.algoPSet.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4) #Are 10 (-5-5). For 50ns is (-4,-2,0,2,4) #No .algoPSet. in old releases\n")
-           outputfile.write("process.ecalMultiFitUncalibRecHit.EBdigiCollection = cms.InputTag('dummyHits','dummyBarrelDigis','analyzerFillEpsilon')\n")
-           outputfile.write("process.ecalMultiFitUncalibRecHit.EEdigiCollection = cms.InputTag('dummyHits','dummyEndcapDigis','analyzerFillEpsilon')\n")
+           if(FixGhostDigis):
+               outputfile.write("process.ecalMultiFitUncalibRecHit.EBdigiCollection = cms.InputTag('cleanedEcalDigis','ebCleanedDigis')\n")
+               outputfile.write("process.ecalMultiFitUncalibRecHit.EEdigiCollection = cms.InputTag('cleanedEcalDigis','eeCleanedDigis')\n")
+           else:
+               outputfile.write("process.ecalMultiFitUncalibRecHit.EBdigiCollection = cms.InputTag('dummyHits','dummyBarrelDigis','analyzerFillEpsilon')\n")
+               outputfile.write("process.ecalMultiFitUncalibRecHit.EEdigiCollection = cms.InputTag('dummyHits','dummyEndcapDigis','analyzerFillEpsilon')\n")               
            outputfile.write("process.ecalMultiFitUncalibRecHit.algoPSet.useLumiInfoRunHeader = False #added this line to make code run\n") #can enable setting --> DigiCustomization = True <-- in parameters.py, but this also set --> outputfile.write("process.ecalMultiFitUncalibRecHit.algoPSet.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4) #Are 10 (-5-5). For 50ns is (-4,-2,0,2,4) \
 #No .algoPSet. in old releases\n")  <-- line above , so I prefer to add it here
         if(WEIGHTS):
            outputfile.write("import RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi\n")
            outputfile.write("process.load('RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi')\n")
            outputfile.write("process.ecalweight =  RecoLocalCalo.EcalRecProducers.ecalGlobalUncalibRecHit_cfi.ecalGlobalUncalibRecHit.clone()\n")
-           outputfile.write("process.ecalweight.EBdigiCollection = cms.InputTag('dummyHits','dummyBarrelDigis','analyzerFillEpsilon')\n")
-           outputfile.write("process.ecalweight.EEdigiCollection = cms.InputTag('dummyHits','dummyEndcapDigis','analyzerFillEpsilon')\n")
+           if(FixGhostDigis):
+               outputfile.write("process.ecalweight.EBdigiCollection = cms.InputTag('cleanedEcalDigis','ebCleanedDigis')\n")
+               outputfile.write("process.ecalweight.EEdigiCollection = cms.InputTag('cleanedEcalDigis','eeCleanedDigis')\n")
+           else:
+               outputfile.write("process.ecalweight.EBdigiCollection = cms.InputTag('dummyHits','dummyBarrelDigis','analyzerFillEpsilon')\n")
+               outputfile.write("process.ecalweight.EEdigiCollection = cms.InputTag('dummyHits','dummyEndcapDigis','analyzerFillEpsilon')\n")               
         outputfile.write("#UNCALIB to CALIB\n")
         outputfile.write("from RecoLocalCalo.EcalRecProducers.ecalRecHit_cfi import *\n")
         outputfile.write("process.ecalDetIdToBeRecovered =  RecoLocalCalo.EcalRecProducers.ecalDetIdToBeRecovered_cfi.ecalDetIdToBeRecovered.clone()\n")
@@ -291,6 +305,8 @@ def printFillCfg2( outputfile, pwd , iteration, outputDir, ijob ):
     outputfile.write("    process.p *= process.ecalPi0ReCorrected\n")
     if (FROMDIGI):
         outputfile.write("process.p *= process.dummyHits\n")
+        if(FixGhostDigis):
+            outputfile.write("process.p *= process.cleanedEcalDigis\n")
         if(MULTIFIT):
            outputfile.write("process.p *= process.ecalMultiFitUncalibRecHit\n")
         if (WEIGHTS):

--- a/submit/parameters.py
+++ b/submit/parameters.py
@@ -14,6 +14,7 @@ SMCalibEB          = False
 EtaRingCalibEE     = False
 SMCalibEE          = False
 CalibMapEtaRing    = "CalibCode/FillEpsilonPlot/data/calibMap.root"
+FixGhostDigis      = True
 #PATH
 #eosPath = '/store/caf/user/lpernie'
 eosPath = '/store/group/dpg_ecal/alca_ecalcalib/piZero2016/emanuele'
@@ -56,16 +57,16 @@ if(isCRAB):
 isMC = False
 MakeNtuple4optimization = False
 #InputList and Folder name
-inputlist_n      = 'InputList/2016B_AlCaP0Raw_run273730.list' # list of input files
-dirname          = 'pi0data_2016B_Run273730_Yong'
+inputlist_n      = 'InputList/2015All_AlCaP0Raw.list' # list of input files
+dirname          = 'pi0data_2015'
 Silent           = False                 # True->Fill modules is silent; False->Fill modules has a standard output
 #TAG, QUEUE and ITERS
-NameTag          = 'pi0data_2016B_Run273730_Yong'                   # Tag to the names to avoid overlap
+NameTag          = 'pi0data_2015'                   # Tag to the names to avoid overlap
 queueForDaemon   = 'cmscaf1nw'          # Option suggested: 2nw/2nd, 1nw/1nd, cmscaf1nw/cmscaf1nd... even cmscaf2nw
 queue            = '8nh'
 nIterations      = 1
 #N files
-ijobmax          = 2                     # 5 number of files per job
+ijobmax          = 5                     # 5 number of files per job
 nHadd            = 35                    # 35 number of files per hadd
 fastHadd         = True                  # From 7_4_X we can use this faster mathod. But files have to be copied on /tmp/ to be converted in .db
 if( isCRAB and isOtherT2 ):
@@ -257,7 +258,7 @@ GeVTagRecord='';GeVTag='';GeVDB=''
 isMC               = False
 isNot_2010         = 'True'                                    # Fit Parameter Range
 HLTResults         = 'True'                                    # Fill the EB(EE) histos only is Eb()ee is fired: it uses GetHLTResults(iEvent, HLTResultsNameEB.Data() );
-json_file          = 'json_DCSONLY.txt' if isMC==False else ''            #/afs/cern.ch/cms/CAF/CMSALCA/ALCA_ECALCALIB/json_ecalonly/
+json_file          = 'json_16Dec2015ReReco_Collisions15_25ns_JSON_Silver_v2.txt' if isMC==False else ''            #/afs/cern.ch/cms/CAF/CMSALCA/ALCA_ECALCALIB/json_ecalonly/
 overWriteGlobalTag = False                                     # Allow to overwrite AlphaTag, Laser correction etc
 doEnenerScale      = 'False'
 doIC               = 'False'                                   # Member of Recalibration Module


### PR DESCRIPTION
* adding the filter to clean the EB and EE digi collections from digi not corresponding to an ECAL DetId
* tested on few files. This can be turned on by switching on the FixGhostDigis in parameters.py to true. The parameter is useful only for 2015. In 2016 stream the ghosts are no more there, but this is not harmful (can stay True)