### PR TITLE
Fix to make the final hadd of the histograms working without filling tmp

### DIFF
--- a/submit/calibJobHandler.py
+++ b/submit/calibJobHandler.py
@@ -215,7 +215,7 @@ p -v epsilonPlots | grep -v Barrel | grep -v Endcap | grep " + outputFile + "_" 
         Fhadd_cfg_n = cfgHaddPath + "/Final_HaddCfg_iter_" + str(iters) + ".sh"
         Fhadd_cfg_f = open( Fhadd_cfg_n, 'w' )
         if(fastHadd):
-            printFinalHaddFAST(Fhadd_cfg_f, haddSrc_final_n_s, dest, pwd )
+            printFinalHaddRegroup(Fhadd_cfg_f, haddSrc_final_n_s, dest, pwd )
         else:
             printFinalHadd(Fhadd_cfg_f, haddSrc_final_n_s, dest, pwd )
         Fhadd_cfg_f.close()

--- a/submit/submitCalibration.py
+++ b/submit/submitCalibration.py
@@ -145,7 +145,7 @@ for iter in range(nIterations):
     Fhadd_cfg_n = cfgHaddPath + "/Final_HaddCfg_iter_" + str(iter) + ".sh"
     Fhadd_cfg_f = open( Fhadd_cfg_n, 'w' )
     if(fastHadd):
-        printFinalHaddFAST(Fhadd_cfg_f, haddSrc_final_n_s, dest, pwd )
+        printFinalHaddRegroup(Fhadd_cfg_f, haddSrc_final_n_s, dest, pwd )
     else:
         printFinalHadd(Fhadd_cfg_f, haddSrc_final_n_s, dest, pwd )
     Fhadd_cfg_f.close()


### PR DESCRIPTION
The current method for making the final hadd of the histogram files was almost 100% of the times failing (for complete EB+EE calibrations with full stat) due to filling the tmp of the worker node.
Typically each file is ~70 MB and typical calibration makes O(100) of these files => ~70 GB x 2, 
while running hadd in local on tmp, before copying to EOS.

Now doing this hadd in steps of n (n=10 by default), removing the inputs at each group
(since being histograms, size(1 merged file) ~ size (1 input file) i.e. 1 TH1F for each crystal)

