### PR TITLE
Remove RooMinuit

### DIFF
--- a/FitEpsilonPlot/interface/FitEpsilonPlot.h
+++ b/FitEpsilonPlot/interface/FitEpsilonPlot.h
@@ -137,7 +137,6 @@ class FitEpsilonPlot : public edm::one::EDAnalyzer<> {
       std::string calibMapPath_; 
       std::string Barrel_orEndcap_; 
       std::string fitFileName_;
-      bool useFit_RooMinuit_;
 
       std::string EEoEB_; 
       bool isNot_2010_; 

--- a/GBRTrain/test/applyenergy.C
+++ b/GBRTrain/test/applyenergy.C
@@ -8,7 +8,6 @@
 #include "RooGaussian.h"
 #include "RooProdPdf.h"
 #include "RooAddPdf.h"
-#include "RooMinuit.h"
 #include "RooNLLVar.h"
 #include "RooFitResult.h"
 #include "RooPlot.h"

--- a/submit/AfterCalibTools/Optimization/Step2_FitHisto.C
+++ b/submit/AfterCalibTools/Optimization/Step2_FitHisto.C
@@ -192,7 +192,7 @@ vector<float> FitFit(TH1D* h, double xmin, double xmax, int events, int Name, FI
   model = &model1;
 
   RooNLLVar nll("nll","log likelihood var",*model,dh,Extended());
-  RooMinuit m(nll);
+  RooMinimizer m(nll);
   m.migrad();
 
   RooFitResult* res = m.save() ;

--- a/submit/AfterCalibTools/PlotMaker/convert_fitIndex_iphiix_ietaiy.C
+++ b/submit/AfterCalibTools/PlotMaker/convert_fitIndex_iphiix_ietaiy.C
@@ -46,7 +46,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/PlotMaker/drawFits.C
+++ b/submit/AfterCalibTools/PlotMaker/drawFits.C
@@ -45,7 +45,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/PlotMaker/drawFitsSingleFile.C
+++ b/submit/AfterCalibTools/PlotMaker/drawFitsSingleFile.C
@@ -45,7 +45,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/PlotMaker/findFitFileFromFitIndex.C
+++ b/submit/AfterCalibTools/PlotMaker/findFitFileFromFitIndex.C
@@ -45,7 +45,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/TestConvergence/Convergence.C
+++ b/submit/AfterCalibTools/TestConvergence/Convergence.C
@@ -5,7 +5,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 #include "RooDataHist.h"
 #include "RooAbsPdf.h"
 #include "RooAddPdf.h"

--- a/submit/AfterCalibTools/WorkOnIC/CheckFit.C
+++ b/submit/AfterCalibTools/WorkOnIC/CheckFit.C
@@ -5,7 +5,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 #include "RooDataHist.h"
 #include "RooAbsPdf.h"
 #include "RooAddPdf.h"

--- a/submit/AfterCalibTools/WorkOnIC/Gaussian_fit.C
+++ b/submit/AfterCalibTools/WorkOnIC/Gaussian_fit.C
@@ -5,7 +5,7 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
+#include "RooMinimizer.h"
 #include "RooDataHist.h"
 #include "RooAbsPdf.h"
 #include "RooAddPdf.h"
@@ -99,7 +99,7 @@ void Gaussian_fit( string Dir, string File ){
 	  RooAddPdf model2("model","sig+bkg",RooArgList(gaus,bkg),RooArgList(Nsig,Nbkg));
 	  RooAbsPdf* model=0; model = &model2;
 	  RooNLLVar nll("nll","log likelihood var",*model,dh);//,Extended());
-	  RooMinuit m(nll);
+	  RooMinimizer m(nll);
 	  m.setVerbose(kFALSE);
 	  m.migrad();
 	  //RooFitResult* res = m.save();

--- a/submit/AfterCalibTools/WorkOnIC/Total_fit.C
+++ b/submit/AfterCalibTools/WorkOnIC/Total_fit.C
@@ -5,7 +5,7 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
+#include "RooMinimizer.h"
 #include "RooDataHist.h"
 #include "RooAbsPdf.h"
 #include "RooAddPdf.h"
@@ -160,7 +160,7 @@ void Total_fit( TString File, TString folder, TString Hname, bool RunOnAll, bool
 
     RooNLLVar nll("nll","log likelihood var",*model,dh,RooFit::Extended(true));//RooFit::Extended(true) fundamental for right ormalization
     //RooAbsReal * nll = model->createNLL(dh); Suggested way
-    RooMinuit m(nll);
+    RooMinimizer m(nll);
     m.setVerbose(kFALSE);
     m.migrad();
     //RooFitResult* res = m.save() ;

--- a/submit/AfterCalibTools/streamStudy/comparePeak.C
+++ b/submit/AfterCalibTools/streamStudy/comparePeak.C
@@ -51,7 +51,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/makeL1seedStudy.C
+++ b/submit/AfterCalibTools/streamStudy/makeL1seedStudy.C
@@ -47,7 +47,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 // #include "DataFormats/DetId/interface/DetId.h"
 // #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/makePi0MassWithFit.C
+++ b/submit/AfterCalibTools/streamStudy/makePi0MassWithFit.C
@@ -49,7 +49,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 #include "RooMinimizer.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
@@ -217,7 +216,7 @@ bool noDeadXtalIn3x3matrixSeededByThisXtal(const TH2F* hDeadXtals = NULL, const 
 
 //   // FIT 1
 //   // copied from ECALpro
-//   // RooMinuit m(nll);
+//   // RooMinimizer m(nll);
 //   // m.setVerbose(kFALSE);
 //   // //m.setVerbose(kTRUE);                                                                                                       
 //   // m.migrad();

--- a/submit/AfterCalibTools/streamStudy/makePi0MassWithFit.C
+++ b/submit/AfterCalibTools/streamStudy/makePi0MassWithFit.C
@@ -214,15 +214,6 @@ bool noDeadXtalIn3x3matrixSeededByThisXtal(const TH2F* hDeadXtals = NULL, const 
 //   RooNLLVar nll("nll","log likelihood var",*model,dh, RooFit::Extended(true));
 //   //RooAbsReal * nll = model->createNLL(dh); //suggetsed way, taht should be the same                                                                                      
 
-//   // FIT 1
-//   // copied from ECALpro
-//   // RooMinimizer m(nll);
-//   // m.setVerbose(kFALSE);
-//   // //m.setVerbose(kTRUE);                                                                                                       
-//   // m.migrad();
-//   // //m.hesse();                                                                                                                          
-//   // RooFitResult* res = m.save() ;
-
 //   // FIT2
 //   // copied from Raffaele Gerosa
 //   RooMinimizer mfit(nll);

--- a/submit/AfterCalibTools/streamStudy/makeRooPlotFromFile.C
+++ b/submit/AfterCalibTools/streamStudy/makeRooPlotFromFile.C
@@ -45,7 +45,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "./CMS_lumi.h"
 

--- a/submit/AfterCalibTools/streamStudy/makeStreamCorrelation.C
+++ b/submit/AfterCalibTools/streamStudy/makeStreamCorrelation.C
@@ -47,7 +47,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 // #include "DataFormats/DetId/interface/DetId.h"
 // #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/makeStreamNxtalStudy.C
+++ b/submit/AfterCalibTools/streamStudy/makeStreamNxtalStudy.C
@@ -47,7 +47,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 // #include "DataFormats/DetId/interface/DetId.h"
 // #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/makeStreamOptim.C
+++ b/submit/AfterCalibTools/streamStudy/makeStreamOptim.C
@@ -47,7 +47,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 // #include "DataFormats/DetId/interface/DetId.h"
 // #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/makeStreamOptim_backup.C
+++ b/submit/AfterCalibTools/streamStudy/makeStreamOptim_backup.C
@@ -47,7 +47,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 // #include "DataFormats/DetId/interface/DetId.h"
 // #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/manageRooPlotFromFile.C
+++ b/submit/AfterCalibTools/streamStudy/manageRooPlotFromFile.C
@@ -51,7 +51,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/overlayMassPlot.C
+++ b/submit/AfterCalibTools/streamStudy/overlayMassPlot.C
@@ -51,7 +51,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/saveRooPlotFromFile.C
+++ b/submit/AfterCalibTools/streamStudy/saveRooPlotFromFile.C
@@ -45,7 +45,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/tmp.C
+++ b/submit/AfterCalibTools/streamStudy/tmp.C
@@ -50,7 +50,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"

--- a/submit/AfterCalibTools/streamStudy/utility.h
+++ b/submit/AfterCalibTools/streamStudy/utility.h
@@ -69,7 +69,6 @@
 #include "RooFitResult.h"
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
 #include "RooMinimizer.h"
 
 using namespace RooFit;
@@ -255,16 +254,7 @@ Pi0FitResult drawHisto(TH1* hist = NULL,
   RooNLLVar nll("nll","log likelihood var",*model,dh, RooFit::Extended(true));
   //RooAbsReal * nll = model->createNLL(dh); //suggetsed way, taht should be the same                                                                                      
 
-  // FIT 1
-  // copied from ECALpro
-  // RooMinuit m(nll);
-  // m.setVerbose(kFALSE);
-  // //m.setVerbose(kTRUE);                                                                                                       
-  // m.migrad();
-  // //m.hesse();                                                                                                                          
-  // RooFitResult* res = m.save() ;
-
-  // FIT2
+  // FIT
   // copied from Raffaele Gerosa
   RooMinimizer mfit(nll);
   mfit.setVerbose(kFALSE);
@@ -454,15 +444,7 @@ Pi0FitResult fitMassSingleHisto(TH1* hist) {
   //RooAbsReal * nll = model->createNLL(dh); //suggetsed way, taht should be the same                                                                                     
 
 
-  // FIT 1
-  // copied from ECALpro
-  // RooMinuit m(nll);
-  // m.setVerbose(kFALSE);
-  // //m.setVerbose(kTRUE);                                                    
-  // m.migrad();
-  // //m.hesse();                                                                 
-  // RooFitResult* res = m.save() ;
-  // FIT2
+  // FIT
   // copied from Raffaele Gerosa
   RooMinimizer mfit(nll);
   mfit.setVerbose(kFALSE);

--- a/submit/methods.py
+++ b/submit/methods.py
@@ -495,8 +495,6 @@ def printFitCfg( outputfile, iteration, outputDir, nIn, nFin, EBorEE, nFit, just
         outputfile.write("process.fitEpsilon.foldInSuperModule = cms.untracked.bool(True)\n")
     else:
         outputfile.write("process.fitEpsilon.foldInSuperModule = cms.untracked.bool(False)\n")
-    if useFit_RooMinuit:
-        outputfile.write("process.fitEpsilon.useFit_RooMinuit = cms.untracked.bool( True )\n")        
     outputfile.write("process.fitEpsilon.Barrel_orEndcap = cms.untracked.string('" + Barrel_or_Endcap + "')\n")
     if not(isCRAB): #If CRAB you have to put the correct path, and you do it on calibJobHandler.py, not on ./submitCalibration.py
         outputfile.write("process.fitEpsilon.EpsilonPlotFileName = cms.untracked.string('" + eosPath + "/" + dirname + "/iter_" + str(iteration) + "/" + NameTag + "epsilonPlots.root')\n")
@@ -518,16 +516,9 @@ def printSubmitFitSrc(outputfile, cfgName, source, destination, pwd, logpath, ju
     outputfile.write("#!/bin/bash\n")
     outputfile.write("cd " + pwd + "\n")
     outputfile.write("eval `scramv1 runtime -sh`\n")
-    # if using RooMinuit fo the fit (obsolete according too RooFit guide), then save some pieces from stdout to check status of fit
-    # this is not needed if one uses RooMinimizer (suggested option) because the printing is different
-    # anyway, these prints doesn't affect the code behaviour, they just fall in the fit log file
     # we keep only the output containing 'FIT_EPSILON:'
-    if useFit_RooMinuit:
-        outputfile.write("echo 'cmsRun " + cfgName + " 2>&1 | awk {quote}/FIT_EPSILON:/ || /WITHOUT CONVERGENCE/ || /HAS CONVERGED/{quote}' > " + logpath  + "\n")
-        outputfile.write("cmsRun " + cfgName + " 2>&1 | awk '/FIT_EPSILON:/ || /WITHOUT CONVERGENCE/ || /HAS CONVERGED/' >> " + logpath  + "\n")
-    else:
-        outputfile.write("echo 'cmsRun " + cfgName + " 2>&1 | awk {quote}/FIT_EPSILON:/{quote}' > " + logpath  + "\n")
-        outputfile.write("cmsRun " + cfgName + " 2>&1 | awk '/FIT_EPSILON:/' >> " + logpath  + "\n")
+    outputfile.write("echo 'cmsRun " + cfgName + " 2>&1 | awk {quote}/FIT_EPSILON:/{quote}' > " + logpath  + "\n")
+    outputfile.write("cmsRun " + cfgName + " 2>&1 | awk '/FIT_EPSILON:/' >> " + logpath  + "\n")
     # if only folding there won't be any actual output in /tmp
     if not justDoHistogramFolding:
         sourcerooplot = source.replace("calibMap","fitRes")

--- a/submit/monitoring/fitMass.C
+++ b/submit/monitoring/fitMass.C
@@ -185,8 +185,8 @@ vector<double> fitMass(TH1F* h, int ick, string prefix="", bool isEB=true)
     mfit.minimize("Minuit2","minimize");
     //cout << "FIT_EPSILON: Minimize hesse " << endl;
     mfit.minimize("Minuit2","hesse");
-    m.migrad();
-    m.hesse();  // sometimes it fails, caution
+    mfit.migrad();
+    mfit.hesse();  // sometimes it fails, caution
     //cout<<"FIT_EPSILON: Estimate minos errors for all parameters"<<endl;
     mfit.minos(RooArgSet(Nsig,Nbkg,mean));
     res = mfit.save() ;

--- a/submit/parameters.py
+++ b/submit/parameters.py
@@ -81,8 +81,6 @@ if justCreateRecHits:
    ijobmax = 1 # when recreating rechits from digis, keep same correspondance of files 
 nHadd            = 35 #35                    # 35 number of files per hadd
 nFit             = 2000 if isMC==False else 10                 # number of fits done in parallel
-useFit_RooMinuit = False if isEoverEtrue else True # if True the fit is done with RooMinuit, otherwise with RooMinimizer. The former is obsolete, but the latter can lead to a CMSSW error which makes the job fail, creating large white strips in the map. This happens often because the fit sees a negative PDF at the border of the fit range, RooFit will try to adjust the fit range to avoid the unphysical region, but after few trials CMSSW throws an error: without CMSSW the fit should actually be able to try several thousands of times before failing
-# However, at least from CMSSW_10_2_X, for EoverEtrue with fits using RooCMSshape+double-Crystal-Ball the fits are much better, so let's use RooMinimizer in that case
 Barrel_or_Endcap = 'ALL_PLEASE'          # Option: 'ONLY_BARREL','ONLY_ENDCAP','ALL_PLEASE'
 ContainmentCorrection = 'EoverEtrue' if isMC==False else 'No' # Option: 'EoverEtrue' , 'No'
 copyCCfileToTMP = True  # copy file from eos to /tmp/, should make jobs faster


### PR DESCRIPTION
`RooMinuit` has been removed with CMSSW_14 and the code does not compile anymore.

This PR removes all references of `RooMinuit` and replaces it with `RooMinimizer` where possible.

This PR is essential to move the automation to CMSSW_14.