### PR TITLE
Add workaround to fix rare file open exceptions in pi0 monitoring.

### DIFF
--- a/submit/monitoring/reconstructPi0_template.py
+++ b/submit/monitoring/reconstructPi0_template.py
@@ -141,6 +141,7 @@ process.source = cms.Source('PoolSource',
                             
                         #'root://cms-xrd-global.cern.ch//store/data/Run2018D/AlCaP0/RAW/v1/000/321/396/00000/248ADA80-FBA1-E811-8742-FA163E7B2F96.root'
                         ),
+                            delayReadingEventProducts=cms.untracked.bool(False), # Workaround for rare FileReadError exceptions. See https://github.com/cms-sw/cmssw/issues/49398
                             skipBadFiles = cms.untracked.bool(False)
 )
 


### PR DESCRIPTION
Add workaround to fix rare file open exceptions in pi0 monitoring.

```
08-Jun-2026 14:17:59 CEST  Successfully opened file root://cms-xrd-global.cern.ch//store/hidata/HIRun2026A/AlCaP0/RAW/v1/000/404/527/00000/949413b6-76be-48a2-a9ee-3d61a3aa1a2e.root?scitag.flow=196664
----- Begin Fatal Exception 08-Jun-2026 14:18:10 CEST-----------------------
An exception of category 'FileReadError' occurred while
   [0] Calling InputSource::getNextItemType
   [1] Reading branch EventAuxiliary
   Additional Info:
      [a] Fatal Root Error: @SUB=TTreeCache::FillBuffer
Inconsistency: fCurrentClusterStart=0 fEntryCurrent=20251 fNextClusterStart=21071 but fEntryCurrent should not be in between the two

----- End Fatal Exception -------------------------------------------------
```

More information: https://github.com/cms-sw/cmssw/issues/49398